### PR TITLE
fix(docker): update path, build statically-linked binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.23 AS builder
 WORKDIR /src
 COPY . .
-RUN go build -o /bin/proxy ./proxy/
+RUN go build -a -installsuffix cgo -o /bin/proxy ./cmd/
 
 FROM scratch
 COPY --from=builder /bin/proxy /bin/proxy


### PR DESCRIPTION
The dockerfile does not build. We need to build the binary statically-linked (`CGO_ENABLED=0`).

Alternatively we could switch to a base image with go installed. 