### PR TITLE
Reduce container image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o hmb-proxy ./cmd/main.go
+RUN go build -ldflags "-s -w" -o hmb-proxy ./cmd/main.go
 
 # FROM scratch
 # COPY --from=builder /src/main /src/main


### PR DESCRIPTION
By dropping the debug symbols we can reduce by 5MB the executable size and improve build speed.

```console
$ bob@xps-tbobm:hmb-proxy ll hmb-proxy*
-rwxrwxr-x 1 bob bob 12M févr. 19 15:32 hmb-proxy-small
-rwxrwxr-x 1 bob bob 17M févr. 19 16:08 hmb-proxy-current
```

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>
