### PR TITLE
Move release management out of CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
   build:
@@ -35,22 +32,3 @@ jobs:
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1
-
-  generate-release:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'main' }}
-    needs:
-      - pre-commit
-      - build
-    name: "Semantic release"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Semantic Release
-        id: release
-        uses: cycjimmy/semantic-release-action@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,39 @@ name: "Publish new version"
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    outputs:
+      released_version: ${{ steps.release.outputs.new_release_version }}
+      released_version_tag: ${{ steps.release.outputs.new_release_git_tag }}
+      new_release: ${{ steps.release.outputs.new_release_published }}
+    name: "Semantic release"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Semantic Release
+        id: release
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build-assets:
     name: "Build Release Assets"
     runs-on: ubuntu-latest
+    if: ${{ needs.tag-release.outputs.new_release == 'true' }}
+    needs:
+      - tag-release
     permissions:
       contents: write
       packages: write
@@ -38,6 +60,9 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
+    if: ${{ needs.tag-release.outputs.new_release == 'true' }}
+    needs:
+      - tag-release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Move Tag / Release generation into the same workflow that publishes artifact to remove the need from manually publishing artifacts

_By default we can not trigger a Workflow from another Workflow_

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>
